### PR TITLE
Export all CSVs

### DIFF
--- a/includes/functions/DB_read_functions.php
+++ b/includes/functions/DB_read_functions.php
@@ -198,7 +198,7 @@ function hemaRatings_createEventInfoCsv($eventID, $dir = "exports/"){
 
 function hemaRatings_createEventRosterCsv($eventID = null, $dir = "exports/"){
 // Creates a .csv file with the eventRoster
-// Format: | Name1 | Name2 | Result1 | Result2 | Stage of Tournament |
+// Format: | Name | Club | Nationality | Gender | HEMA Ratings ID |
 
 
 // Get roster/event information
@@ -209,23 +209,21 @@ function hemaRatings_createEventRosterCsv($eventID = null, $dir = "exports/"){
 	}
 
 	$eventRoster = hemaRatings_GetEventRosterForExport($eventID);
-	$eventName = getEventName($eventID);
 	$fileName = "{$dir}fighters.csv";
 
 // Create the CSV file
 	$fp = fopen($fileName, 'w');
 
+	fputcsv($fp, ['Name', 'Club', 'Nationality', 'Gender', 'HEMA Ratings ID']);
+
 	foreach ($eventRoster as $fields) {
-
-		fputs($fp, getFighterNameSystem($fields['systemRosterID'], 'first').",");
-		fputs($fp, $fields['schoolFullName'].",");
-		fputs($fp, $fields['countryIso2'].",");
-		fputs($fp, ",");
-		fputs($fp, $fields['HemaRatingsID']);
-
-		fputs($fp, '');
-
-		fputs($fp, PHP_EOL);
+		fputcsv($fp, [
+			getFighterNameSystem($fields['systemRosterID'], 'first'),
+			$fields['schoolFullName'],
+			$fields['countryIso2'],
+			'',
+			$fields['HemaRatingsID'],
+		]);
 	}
 	fclose($fp);
 

--- a/includes/functions/DB_read_functions.php
+++ b/includes/functions/DB_read_functions.php
@@ -539,6 +539,8 @@ function hemaRatings_createTournamentResultsCsv($tournamentID, $dir = "exports/"
 // Create the CSV file
 	$fp = fopen($fileName, 'w');
 
+	fputcsv($fp, ['Fighter 1', 'Fighter 2', 'Fighter 1 result', 'Fighter 2 result', 'Round']);
+
 	foreach($finishedMatches as $match){
 
 		$winnerID = (int)$match['winnerID'];
@@ -578,15 +580,7 @@ function hemaRatings_createTournamentResultsCsv($tournamentID, $dir = "exports/"
 
 		$fields = [$fighter1, $fighter2, $f1Result, $f2Result, $stageName];
 
-		$comma = ',';
-
-		foreach($fields as $index => $field){
-			if ($index == sizeof($fields)-1){
-				$comma = null;
-			}
-			fputs($fp, $field.$comma);
-		}
-		fputs($fp, PHP_EOL);
+		fputcsv($fp, $fields);
 
 	}
 	fclose($fp);

--- a/includes/functions/DB_read_functions.php
+++ b/includes/functions/DB_read_functions.php
@@ -134,6 +134,29 @@ function hemaRatings_GetEventRosterForExport($eventID){
 
 /******************************************************************************/
 
+function hemaRatings_GetEventClubsForExport($eventID){
+
+	$eventID = (int)$eventID;
+
+	if($eventID == 0){
+		setAlert(SYSTEM,"No eventID in hemaRatings_GetEventClubsForExport()");
+		return;
+	}
+
+	// Distinct clubs that had fighters at the event, ignoring the
+	// *Unknown (1) and *Unaffiliated (2) placeholder schools.
+	$sql = "SELECT DISTINCT sch.schoolFullName, sch.countryIso2,
+				sch.schoolProvince, sch.schoolCity
+			FROM eventRoster ev
+			INNER JOIN systemSchools sch ON ev.schoolID = sch.schoolID
+			WHERE ev.eventID = {$eventID}
+			AND ev.schoolID NOT IN (1, 2)
+			ORDER BY sch.schoolFullName";
+	return mysqlQuery($sql, ASSOC);
+}
+
+/******************************************************************************/
+
 function hemaRatings_getFighterID($systemRosterID){
 	$systemRosterID = (int)$systemRosterID;
 
@@ -223,6 +246,42 @@ function hemaRatings_createEventRosterCsv($eventID = null, $dir = "exports/"){
 			$fields['countryIso2'],
 			'',
 			$fields['HemaRatingsID'],
+		]);
+	}
+	fclose($fp);
+
+	return $fileName;
+}
+
+/******************************************************************************/
+
+function hemaRatings_createClubsCsv($eventID = null, $dir = "exports/"){
+// Creates a .csv file with the clubs that had fighters at the event
+// Format: | Club Name | Country | State | City | Website URL | Facebook URL | Parent club |
+
+	if($eventID == null){$eventID = $_SESSION['eventID'];}
+	if($eventID == null){
+		setAlert(SYSTEM,"No Event ID in hemaRatings_createClubsCsv()");
+		return;
+	}
+
+	$clubList = hemaRatings_GetEventClubsForExport($eventID);
+	$fileName = "{$dir}clubs.csv";
+
+// Create the CSV file
+	$fp = fopen($fileName, 'w');
+
+	fputcsv($fp, ['Club Name', 'Country', 'State', 'City', 'Website URL', 'Facebook URL', 'Parent club']);
+
+	foreach((array)$clubList as $club){
+		fputcsv($fp, [
+			$club['schoolFullName'],
+			$club['countryIso2'],
+			$club['schoolProvince'],
+			$club['schoolCity'],
+			'',
+			'',
+			'',
 		]);
 	}
 	fclose($fp);

--- a/includes/functions/data_handling_functions.php
+++ b/includes/functions/data_handling_functions.php
@@ -591,6 +591,7 @@ function uploadCsvFile($fileName){
 /******************************************************************************/
 
 function uploadZipFile($filesToZip){
+// $filesToZip maps the name to use inside the archive => the file on disk
 
 	$zip = new ZipArchive();
 	$zipName = EXPORT_DIR."export.zip";
@@ -601,10 +602,10 @@ function uploadZipFile($filesToZip){
 	}
 
 
-	//add each file to the archive under its base name
-	foreach($filesToZip as $file)
+	//add each file to the archive under its given name
+	foreach($filesToZip as $archiveName => $file)
 	{
-		$zip->addFile($file, basename($file));
+		$zip->addFile($file, $archiveName);
 	}
 	$zip->close();
 

--- a/includes/functions/data_handling_functions.php
+++ b/includes/functions/data_handling_functions.php
@@ -601,12 +601,18 @@ function uploadZipFile($filesToZip){
 	}
 
 
-	//add each files of $file_name array to archive
-	foreach($filesToZip as $files)
+	//add each file to the archive under its base name
+	foreach($filesToZip as $file)
 	{
-		$zip->addFile(EXPORT_DIR.$files);
+		$zip->addFile($file, basename($file));
 	}
 	$zip->close();
+
+	//remove the source files now that they are in the archive
+	foreach($filesToZip as $file)
+	{
+		unlink($file);
+	}
 
 	if (file_exists($zipName)) {
 		header('Content-Type: application/zip');

--- a/includes/functions/doPOST.php
+++ b/includes/functions/doPOST.php
@@ -956,7 +956,17 @@ function hemaRatings_ExportCsv($informationType){
 
 	if($informationType == 'all'){
 
-		$csvNames[0] = hemaRatings_createEventRosterCsv($_SESSION['eventID'], EXPORT_DIR);
+		$eventID = $_SESSION['eventID'];
+
+		$csvNames = [];
+		$csvNames[] = hemaRatings_createClubsCsv($eventID, EXPORT_DIR);
+		$csvNames[] = hemaRatings_createEventRosterCsv($eventID, EXPORT_DIR);
+
+		$tournamentList = getTournamentsFull($eventID);
+		foreach((array)$tournamentList as $tournamentID => $tournament){
+			$csvNames[] = hemaRatings_createTournamentResultsCsv($tournamentID, EXPORT_DIR);
+		}
+
 		uploadZipFile($csvNames);
 
 	} elseif($informationType == 'eventInfo'){

--- a/includes/functions/doPOST.php
+++ b/includes/functions/doPOST.php
@@ -958,16 +958,27 @@ function hemaRatings_ExportCsv($informationType){
 
 		$eventID = $_SESSION['eventID'];
 
-		$csvNames = [];
-		$csvNames[] = hemaRatings_createClubsCsv($eventID, EXPORT_DIR);
-		$csvNames[] = hemaRatings_createEventRosterCsv($eventID, EXPORT_DIR);
+		// Maps the name to use inside the zip => the file on disk.
+		$files = [];
+		$files['clubs.csv']    = hemaRatings_createClubsCsv($eventID, EXPORT_DIR);
+		$files['fighters.csv'] = hemaRatings_createEventRosterCsv($eventID, EXPORT_DIR);
 
 		$tournamentList = getTournamentsFull($eventID);
 		foreach((array)$tournamentList as $tournamentID => $tournament){
-			$csvNames[] = hemaRatings_createTournamentResultsCsv($tournamentID, EXPORT_DIR);
+
+			$csvFile = hemaRatings_createTournamentResultsCsv($tournamentID, EXPORT_DIR);
+
+			// Move the file to a path that is unique per tournament so two
+			// tournaments with the same name don't overwrite each other on
+			// disk, then give it an archive name that is unique in the zip.
+			$diskPath = EXPORT_DIR.$tournamentID.'-'.basename($csvFile);
+			rename($csvFile, $diskPath);
+
+			$archiveName = hemaRatings_uniqueArchiveName(basename($csvFile), $files);
+			$files[$archiveName] = $diskPath;
 		}
 
-		uploadZipFile($csvNames);
+		uploadZipFile($files);
 
 	} elseif($informationType == 'eventInfo'){
 
@@ -989,6 +1000,28 @@ function hemaRatings_ExportCsv($informationType){
 		$_SESSION['alertMessages']['systemErrors'][] = 'Invalid informationType provided to hemaRatings_ExportCsv()';
 	}
 
+}
+
+/******************************************************************************/
+
+function hemaRatings_uniqueArchiveName($name, $existing){
+// Returns $name, or "name (2).ext", "name (3).ext" etc. so it does not
+// collide with an archive name already used as a key in $existing.
+
+	if(!isset($existing[$name])){
+		return $name;
+	}
+
+	$base = pathinfo($name, PATHINFO_FILENAME);
+	$ext = pathinfo($name, PATHINFO_EXTENSION);
+
+	$counter = 2;
+	do {
+		$candidate = "{$base} ({$counter}).{$ext}";
+		$counter++;
+	} while(isset($existing[$candidate]));
+
+	return $candidate;
 }
 
 /******************************************************************************/

--- a/statsResultsDump.php
+++ b/statsResultsDump.php
@@ -153,6 +153,14 @@ function HemaRatingExportOptions($tournamentList){
 			<input type='hidden' name='formName' value='hemaRatings_ExportCsv'>
 
 
+		<!-- Export everything as a single zip -->
+			<div class='large-12 cell'>
+				<button class='button success' name='HemaRatingsExport' value='all'>
+					Export All (clubs, fighters &amp; tournaments) as .zip
+				</button>
+			</div>
+
+
 		<!-- Export roster -->
 			<div class='large-3 medium-4 cell'>
 


### PR DESCRIPTION
This PR does a few things for CSV export (specifically for HEMA Ratings):

- Fixes a bug where the paths were double prepended which could result in an empty zip file
- Changes writing the CSV using `fputcsv` to avoid issues with commas or other characters causing CSV corruption
- Matches the HEMA Ratings format for CSVs more closely for exports
  * Add the optional clubs information file
  * Adds headers to the CSV export
- Finishes the logic for/adds the ability to export all tournaments/rosters in one zip file

Fixes #32 