### PR TITLE
Fix some bracket bugs

### DIFF
--- a/finalsBracket.php
+++ b/finalsBracket.php
@@ -874,6 +874,10 @@ function bracket_finalistEntry($fighterNum,$matchInfo, $bracketInfo, $finalists,
 		?>
 
 		<div class='<?=$class?>' style='<?=$style?> padding-left: 3px;'>
+			<?php if(ALLOW['EVENT_SCOREKEEP'] == true): ?>
+				<input type='hidden' name='newFinalists[<?=$matchID?>][<?=$fighterNum?>]'
+					value='<?=$matchInfo[$fighterID]?>'>
+			<?php endif ?>
 			<?=$score?> <?=$name?>
 			<?php if($teamFighters != ""){
 				tooltip($teamFighters);

--- a/includes/functions/DB_write_functions.php
+++ b/includes/functions/DB_write_functions.php
@@ -7503,6 +7503,12 @@ function updateFinalsBracket(){
 			$finalists[1] = (int)@$finalists[1];
 			$finalists[2] = (int)@$finalists[2];
 
+			// A match can't have the same fighter on both sides.
+			if($finalists[1] != 0 && $finalists[1] == $finalists[2]){
+				setAlert(USER_ERROR, "A match can't have the same fighter on both sides.");
+				continue;
+			}
+
 			// Only reset the match when the fighters actually change.
 			// Re-submitting the same fighters (eg an accidental click) must
 			// not wipe a match that has already been scored. To clear a match
@@ -7533,16 +7539,18 @@ function updateFinalsBracket(){
 			if(!empty($finalists[1])){
 				$sql = "UPDATE eventMatches
 						SET fighter1ID = {$finalists[1]}
-						WHERE matchID = {$matchID}
-						OR placeholderMatchID = {$matchID}";
+						WHERE (matchID = {$matchID}
+							OR placeholderMatchID = {$matchID})
+						AND fighter2ID != {$finalists[1]}";
 				mysqlQuery($sql, SEND);
 			}
 
 			if(!empty($finalists[2])){
 				$sql = "UPDATE eventMatches
 						SET fighter2ID = {$finalists[2]}
-						WHERE matchID = {$matchID}
-						OR placeholderMatchID = {$matchID}";
+						WHERE (matchID = {$matchID}
+							OR placeholderMatchID = {$matchID})
+						AND fighter1ID != {$finalists[2]}";
 				mysqlQuery($sql, SEND);
 			}
 

--- a/includes/functions/DB_write_functions.php
+++ b/includes/functions/DB_write_functions.php
@@ -7503,9 +7503,28 @@ function updateFinalsBracket(){
 			$finalists[1] = (int)@$finalists[1];
 			$finalists[2] = (int)@$finalists[2];
 
-			if(!empty($finalists[1]) && !empty($finalists[2])){
+			// Only reset the match when the fighters actually change.
+			// Re-submitting the same fighters (eg an accidental click) must
+			// not wipe a match that has already been scored. To clear a match
+			// use the 'Clear Selected' button instead.
+			$current = mysqlQuery("SELECT fighter1ID, fighter2ID
+									FROM eventMatches
+									WHERE matchID = {$matchID}", SINGLE);
+			$fightersChanged = (!empty($finalists[1]) && $finalists[1] != (int)@$current['fighter1ID'])
+							|| (!empty($finalists[2]) && $finalists[2] != (int)@$current['fighter2ID']);
+
+			if(!empty($finalists[1]) && !empty($finalists[2]) && $fightersChanged){
 				$sql = "DELETE eventExchanges FROM eventExchanges
 						INNER JOIN eventMatches USING(matchID)
+						WHERE matchID = {$matchID}
+						OR placeholderMatchID = {$matchID}";
+				mysqlQuery($sql, SEND);
+
+				// The exchanges are gone, so reset the derived match state too.
+				// Otherwise the previous fighters' score is left on the match.
+				$sql = "UPDATE eventMatches
+						SET fighter1Score = null, fighter2Score = null, matchTime = 0,
+							winnerID = null, matchComplete = 0, signOff1 = 0, signOff2 = 0
 						WHERE matchID = {$matchID}
 						OR placeholderMatchID = {$matchID}";
 				mysqlQuery($sql, SEND);

--- a/includes/functions/DB_write_functions.php
+++ b/includes/functions/DB_write_functions.php
@@ -7514,7 +7514,17 @@ function updateFinalsBracket(){
 				continue;
 			}
 
-			if(bracketMatchNeedsReset($finalists, $matchID)){
+			$currentFighters = mysqlQuery("SELECT fighter1ID, fighter2ID
+											FROM eventMatches
+											WHERE matchID = {$matchID}", SINGLE);
+
+			// Re-submitting the same fighters (eg an accidental click) is a
+			// no-op. To clear a match use the 'Clear Selected' button instead.
+			if(bracketFinalistsAreUnchanged($finalists, $currentFighters)){
+				continue;
+			}
+
+			if(bracketMatchNeedsReset($finalists, $currentFighters)){
 				$sql = "DELETE eventExchanges FROM eventExchanges
 						INNER JOIN eventMatches USING(matchID)
 						WHERE matchID = {$matchID}
@@ -7572,7 +7582,16 @@ function bracketFinalistsAreSameFighter($finalists){
 
 /******************************************************************************/
 
-function bracketMatchNeedsReset($finalists, $matchID){
+function bracketFinalistsAreUnchanged($finalists, $currentFighters){
+// True when the submission matches the fighters already in the match.
+
+	return $finalists[1] == (int)@$currentFighters['fighter1ID']
+		&& $finalists[2] == (int)@$currentFighters['fighter2ID'];
+}
+
+/******************************************************************************/
+
+function bracketMatchNeedsReset($finalists, $currentFighters){
 // True when both fighters are set and at least one differs from who is
 // currently in the match, so the old exchanges and score should be cleared.
 
@@ -7580,13 +7599,8 @@ function bracketMatchNeedsReset($finalists, $matchID){
 		return false;
 	}
 
-	$matchID = (int)$matchID;
-	$current = mysqlQuery("SELECT fighter1ID, fighter2ID
-							FROM eventMatches
-							WHERE matchID = {$matchID}", SINGLE);
-
-	return $finalists[1] != (int)@$current['fighter1ID']
-		|| $finalists[2] != (int)@$current['fighter2ID'];
+	return $finalists[1] != (int)@$currentFighters['fighter1ID']
+		|| $finalists[2] != (int)@$currentFighters['fighter2ID'];
 }
 
 /******************************************************************************/

--- a/includes/functions/DB_write_functions.php
+++ b/includes/functions/DB_write_functions.php
@@ -7503,8 +7503,13 @@ function updateFinalsBracket(){
 			$finalists[1] = (int)@$finalists[1];
 			$finalists[2] = (int)@$finalists[2];
 
+			// Nothing was submitted for this match.
+			if(empty($finalists[1]) && empty($finalists[2])){
+				continue;
+			}
+
 			// A match can't have the same fighter on both sides.
-			if($finalists[1] != 0 && $finalists[1] == $finalists[2]){
+			if($finalists[1] == $finalists[2]){
 				setAlert(USER_ERROR, "A match can't have the same fighter on both sides.");
 				continue;
 			}

--- a/includes/functions/DB_write_functions.php
+++ b/includes/functions/DB_write_functions.php
@@ -7514,9 +7514,10 @@ function updateFinalsBracket(){
 				continue;
 			}
 
-			$currentFighters = mysqlQuery("SELECT fighter1ID, fighter2ID
-											FROM eventMatches
-											WHERE matchID = {$matchID}", SINGLE);
+			$sql = "SELECT fighter1ID, fighter2ID
+					FROM eventMatches
+					WHERE matchID = {$matchID}";
+			$currentFighters = mysqlQuery($sql, SINGLE);
 
 			// Re-submitting the same fighters (eg an accidental click) is a
 			// no-op. To clear a match use the 'Clear Selected' button instead.
@@ -7538,7 +7539,7 @@ function updateFinalsBracket(){
 							winnerID = null, matchComplete = 0, signOff1 = 0, signOff2 = 0
 						WHERE matchID = {$matchID}
 						OR placeholderMatchID = {$matchID}";
-				mysqlQuery($sql, SEND);
+				////mysqlQuery($sql, SEND); <-- Note this code is correct, however the fact that this housekeeping is never being done has been saving our ass. I'd preffer to be 100% sure it's gone from the field before adding it back in. (Sean)
 			}
 
 			if(!empty($finalists[1])){
@@ -7546,7 +7547,8 @@ function updateFinalsBracket(){
 						SET fighter1ID = {$finalists[1]}
 						WHERE (matchID = {$matchID}
 							OR placeholderMatchID = {$matchID})
-						AND fighter2ID != {$finalists[1]}";
+						AND (    fighter2ID != {$finalists[1]}
+							  OR fighter2ID IS NULL)";
 				mysqlQuery($sql, SEND);
 			}
 
@@ -7555,7 +7557,8 @@ function updateFinalsBracket(){
 						SET fighter2ID = {$finalists[2]}
 						WHERE (matchID = {$matchID}
 							OR placeholderMatchID = {$matchID})
-						AND fighter1ID != {$finalists[2]}";
+						AND (    fighter1ID != {$finalists[2]}
+							  OR fighter1ID IS NULL)";
 				mysqlQuery($sql, SEND);
 			}
 
@@ -7569,7 +7572,7 @@ function updateFinalsBracket(){
 function bracketFinalistsAreEmpty($finalists){
 // True when nothing was submitted for the match.
 
-	return empty($finalists[1]) && empty($finalists[2]);
+	return (empty($finalists[1]) && empty($finalists[2]));
 }
 
 /******************************************************************************/
@@ -7577,7 +7580,7 @@ function bracketFinalistsAreEmpty($finalists){
 function bracketFinalistsAreSameFighter($finalists){
 // True when the same fighter was picked for both sides of the match.
 
-	return $finalists[1] == $finalists[2];
+	return ($finalists[1] == $finalists[2]);
 }
 
 /******************************************************************************/
@@ -7585,8 +7588,8 @@ function bracketFinalistsAreSameFighter($finalists){
 function bracketFinalistsAreUnchanged($finalists, $currentFighters){
 // True when the submission matches the fighters already in the match.
 
-	return $finalists[1] == (int)@$currentFighters['fighter1ID']
-		&& $finalists[2] == (int)@$currentFighters['fighter2ID'];
+	return (	$finalists[1] == (int)@$currentFighters['fighter1ID']
+			 &&	$finalists[2] == (int)@$currentFighters['fighter2ID']);
 }
 
 /******************************************************************************/
@@ -7599,8 +7602,8 @@ function bracketMatchNeedsReset($finalists, $currentFighters){
 		return false;
 	}
 
-	return $finalists[1] != (int)@$currentFighters['fighter1ID']
-		|| $finalists[2] != (int)@$currentFighters['fighter2ID'];
+	return (	$finalists[1] != (int)@$currentFighters['fighter1ID']
+			 ||	$finalists[2] != (int)@$currentFighters['fighter2ID']);
 }
 
 /******************************************************************************/

--- a/includes/functions/DB_write_functions.php
+++ b/includes/functions/DB_write_functions.php
@@ -7504,27 +7504,17 @@ function updateFinalsBracket(){
 			$finalists[2] = (int)@$finalists[2];
 
 			// Nothing was submitted for this match.
-			if(empty($finalists[1]) && empty($finalists[2])){
+			if(bracketFinalistsAreEmpty($finalists)){
 				continue;
 			}
 
 			// A match can't have the same fighter on both sides.
-			if($finalists[1] == $finalists[2]){
+			if(bracketFinalistsAreSameFighter($finalists)){
 				setAlert(USER_ERROR, "A match can't have the same fighter on both sides.");
 				continue;
 			}
 
-			// Only reset the match when the fighters actually change.
-			// Re-submitting the same fighters (eg an accidental click) must
-			// not wipe a match that has already been scored. To clear a match
-			// use the 'Clear Selected' button instead.
-			$current = mysqlQuery("SELECT fighter1ID, fighter2ID
-									FROM eventMatches
-									WHERE matchID = {$matchID}", SINGLE);
-			$fightersChanged = (!empty($finalists[1]) && $finalists[1] != (int)@$current['fighter1ID'])
-							|| (!empty($finalists[2]) && $finalists[2] != (int)@$current['fighter2ID']);
-
-			if(!empty($finalists[1]) && !empty($finalists[2]) && $fightersChanged){
+			if(bracketMatchNeedsReset($finalists, $matchID)){
 				$sql = "DELETE eventExchanges FROM eventExchanges
 						INNER JOIN eventMatches USING(matchID)
 						WHERE matchID = {$matchID}
@@ -7562,6 +7552,41 @@ function updateFinalsBracket(){
 		}
 	}
 
+}
+
+/******************************************************************************/
+
+function bracketFinalistsAreEmpty($finalists){
+// True when nothing was submitted for the match.
+
+	return empty($finalists[1]) && empty($finalists[2]);
+}
+
+/******************************************************************************/
+
+function bracketFinalistsAreSameFighter($finalists){
+// True when the same fighter was picked for both sides of the match.
+
+	return $finalists[1] == $finalists[2];
+}
+
+/******************************************************************************/
+
+function bracketMatchNeedsReset($finalists, $matchID){
+// True when both fighters are set and at least one differs from who is
+// currently in the match, so the old exchanges and score should be cleared.
+
+	if(empty($finalists[1]) || empty($finalists[2])){
+		return false;
+	}
+
+	$matchID = (int)$matchID;
+	$current = mysqlQuery("SELECT fighter1ID, fighter2ID
+							FROM eventMatches
+							WHERE matchID = {$matchID}", SINGLE);
+
+	return $finalists[1] != (int)@$current['fighter1ID']
+		|| $finalists[2] != (int)@$current['fighter2ID'];
 }
 
 /******************************************************************************/


### PR DESCRIPTION
I did some spelunking and I think I found out the issues in #198.  At least the first bug that's detailed.

- With this PR, the match is only reset when its fighters actually change; re-submitting the same fighters is a no-op.  I think someone might have clicked "Add Fighters" without changing anything, which would cause the funky reset.
  * Users should use "Clear Selected" to deliberately reset the data.
- When you are reassigning bracket fighters to different fighters, the code no longer leaves a stale score behind.  Before it wasn't recomputing the derived state when the exchanges went away.
- A side thing I found, a match can no longer be saved with the same fighter on both sides (rejected with an alert, plus a guard on the update).

As for the fighter color swap, that update is atomic when clicking the button to swap the colors, so I can't think of a path that would allow for the described behavior to happen.  So, this PR fixes #198 (at least mostly).
