### PR TITLE
Make landing page event fetch efficient

### DIFF
--- a/includes/functions/DB_read_functions.php
+++ b/includes/functions/DB_read_functions.php
@@ -1917,6 +1917,8 @@ function getEventListByPublication($orderBy = 'name', $dayLimit = null){
 		$dateClause = "AND eventEndDate >= DATE_SUB(CURDATE(), INTERVAL {$dayLimit} DAY)";
 	}
 
+	// Use implode here to keep it compact and memory efficient since we don't
+	// know exactly how many clauses we're joining.
 	$whereClause = empty($conditions) ? "" : "WHERE ".implode("\n\t\t\t\tAND ", $conditions);
 
 	if($orderBy == 'date'){

--- a/includes/functions/DB_read_functions.php
+++ b/includes/functions/DB_read_functions.php
@@ -1894,18 +1894,30 @@ function getEventListSmall(){
 
 /******************************************************************************/
 
-function getEventListByPublication($orderBy = 'name'){
+function getEventListByPublication($orderBy = 'name', $dayLimit = null){
+
+	$conditions = [];
 
 	if(ALLOW['VIEW_HIDDEN'] == false){
-		$whereClause = "WHERE isArchived = 1
+		$conditions[] = "(isArchived = 1
 						OR publishDescription = 1
 						OR publishRoster = 1
 						OR publishSchedule = 1
 						OR publishMatches = 1
-						OR publishRules = 1";
-	} else {
-		$whereClause = "";
+						OR publishRules = 1)";
 	}
+
+	// Optionally only return events that ended within the last $dayLimit days
+	// (or are still upcoming), so callers that only show recent events don't
+	// have to pull the entire event history.
+	$dateClause = "";
+	if($dayLimit !== null){
+		$dayLimit = (int)$dayLimit;
+		$conditions[] = "eventEndDate >= DATE_SUB(CURDATE(), INTERVAL {$dayLimit} DAY)";
+		$dateClause = "AND eventEndDate >= DATE_SUB(CURDATE(), INTERVAL {$dayLimit} DAY)";
+	}
+
+	$whereClause = empty($conditions) ? "" : "WHERE ".implode("\n\t\t\t\tAND ", $conditions);
 
 	if($orderBy == 'date'){
 		$orderClause = "eventStartDate ASC";
@@ -1944,6 +1956,7 @@ function getEventListByPublication($orderBy = 'name'){
 			AND publishMatches = 0
 			AND publishRules = 0
 			AND userID = {$userID}
+			{$dateClause}
 		ORDER BY {$orderClause}";
 
 		$personalEvents = mysqlQuery($sql, ASSOC);

--- a/infoWelcome.php
+++ b/infoWelcome.php
@@ -28,8 +28,6 @@ include('includes/header.php');
 		$dateDiffStart = compareDates($event['eventStartDate']);
 		$dateDiffEnd = compareDates($event['eventEndDate']);
 
-		if($dateDiffEnd > 14){ continue; }
-
 		$event['displayClass'] = "";
 
 

--- a/infoWelcome.php
+++ b/infoWelcome.php
@@ -15,7 +15,7 @@ $pageName = "Welcome to HEMA Scorecard";
 
 include('includes/header.php');
 
-	$eventList = getEventListByPublication('date');
+	$eventList = getEventListByPublication('date', 14);
 
 	$eventsToShow['active'] = [];
 	$eventsToShow['recent'] = [];

--- a/infoWelcome.php
+++ b/infoWelcome.php
@@ -173,7 +173,7 @@ function displayEventTabe($eventList){
 		<?php foreach($eventList as $event): ?>
 			<tr onclick="changeEventJs(<?=$event['eventID']?>)" class='link-table <?=$event['displayClass']?>'>
 				<td><?=$event['eventStartDate']?></td>
-				<td><?=getEventName($event['eventID'])?></td>
+				<td><?=$event['eventName']?> <?=$event['eventYear']?></td>
 				<td><?=$event['countryName']?> (<?=$event['eventCity']?>, <?=$event['eventProvince']?>)</td>
 				<td class='hide-for-small-only'><?=$event['displayStatus']?></td>
 			</tr>


### PR DESCRIPTION
When I was working on the other landing page PR, I noticed we're fetching every event and filtering them in PHP.  This PR date bounds the query so we only fetch the events we care about in the first place.  It should speed rendering that page up considerably.