### PR TITLE
E2E test harness setup

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shell scripts and SQL fixtures run inside Linux containers / CI —
+# they must keep LF endings regardless of contributor autocrlf settings.
+*.sh text eol=lf
+*.sql text eol=lf

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,64 @@
+name: E2E Tests
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+
+      # Started first so MySQL seeds and the web container compiles mysqli
+      # while Node/Playwright install below.
+      - name: Start app stack
+        run: docker compose -f docker-compose.test.yml -p hemascorecard-test up -d
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      # Belt and suspenders: Playwright's global setup also polls this for
+      # 120s, but failing here gives a clearer signal and container logs.
+      - name: Wait for app
+        run: |
+          for i in $(seq 1 60); do
+            code=$(curl -s -o /dev/null -w '%{http_code}' http://localhost:8000/healthcheck.php || true)
+            if [ "$code" = "200" ]; then
+              echo "App ready."
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "App did not become ready within 180s (last status: $code)"
+          docker compose -f docker-compose.test.yml -p hemascorecard-test logs --tail=100
+          exit 1
+
+      - name: Run Playwright tests
+        run: npx playwright test
+        env:
+          CI: true
+
+      - name: Upload Playwright report
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: |
+            playwright-report/
+            test-results/
+          retention-days: 14
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: docker compose -f docker-compose.test.yml -p hemascorecard-test logs --tail=200

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [master]
 
+# Lock to only running the most recent push and cancel previous.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   e2e:
     runs-on: ubuntu-latest
@@ -12,21 +17,21 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      # Started first so MySQL seeds and the web container compiles mysqli
-      # while Node/Playwright install below.
-      - name: Start app stack
-        run: docker compose -f docker-compose.test.yml -p hemascorecard-test up -d
+      # Setup Steps
+      - parallel:
+        - name: Start app stack
+          run: docker compose -f docker-compose.test.yml -p hemascorecard-test up -d
 
-      - uses: actions/setup-node@v6
-        with:
-          node-version: 20
-          cache: npm
+        - uses: actions/setup-node@v6
+          with:
+            node-version: 20
+            cache: npm
 
-      - name: Install dependencies
-        run: npm ci
+        - name: Install dependencies
+          run: npm ci
 
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium
+        - name: Install Playwright browsers
+          run: npx playwright install --with-deps chromium
 
       # Belt and suspenders: Playwright's global setup also polls this for
       # 120s, but failing here gives a clearer signal and container logs.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -10,14 +10,14 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Started first so MySQL seeds and the web container compiles mysqli
       # while Node/Playwright install below.
       - name: Start app stack
         run: docker compose -f docker-compose.test.yml -p hemascorecard-test up -d
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,9 @@
 data/
 !/**/.gitkeep
+
+# Node / Playwright
+node_modules/
+test-results/
+playwright-report/
+blob-report/
+tests/e2e/.auth/

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,0 +1,49 @@
+# Isolated stack for E2E testing (Playwright). Standalone file — NOT an
+# override of docker-compose.yml (override merging cannot remove the base
+# file's ./data bind mount, which would defeat isolation).
+#
+# Usage:
+#   docker compose -f docker-compose.test.yml -p hemascorecard-test up -d
+#   docker compose -f docker-compose.test.yml -p hemascorecard-test down
+#
+# The database lives on tmpfs: every `up` starts fresh from the schema +
+# seed, and the dev stack's ./data directory is never touched. To reset the
+# DB between test runs without restarting containers, run tests/reset-db.sh.
+#
+# Note: uses port 8000 like the dev stack, so the two cannot run at the
+# same time.
+services:
+  web:
+    image: "php:7.4-cli"
+    ports:
+      - "8000:8000"
+    volumes:
+      - .:/hemaScorecard
+    # No xdebug (slow to install, unneeded in CI) and no migrations step
+    # (migrations/run.php does not exist in the repo).
+    command: >
+      sh -c "docker-php-ext-install mysqli &&
+             php -S 0.0.0.0:8000 -t /hemaScorecard"
+    environment:
+      DEPLOYMENT: 2 # DEPLOYMENT_TEST — shows the "Test Server" banner
+      PRIMARY_DATABASE: ScorecardV5
+      DATABASE_HOST: db
+      DATABASE_USER: user
+      DATABASE_PASSWORD: passw0rd
+    links:
+      - db
+  db:
+    image: "mysql:5.7.33"
+    environment:
+      MYSQL_DATABASE: ScorecardV5
+      MYSQL_USER: user
+      MYSQL_PASSWORD: passw0rd
+      MYSQL_ROOT_PASSWORD: passw0rd
+    tmpfs:
+      - /var/lib/mysql
+    volumes:
+      # Individual file mounts (not the whole ./includes dir) so init order
+      # is explicit: schema -> admin user -> test seed.
+      - "./includes/Tables - ScorecardV9.sql:/docker-entrypoint-initdb.d/01-schema.sql:ro"
+      - "./includes/Tables - Setup_Docker.sql:/docker-entrypoint-initdb.d/02-users.sql:ro"
+      - "./tests/fixtures/seed.sql:/docker-entrypoint-initdb.d/03-seed.sql:ro"

--- a/docs/E2E_TESTING_GUIDE.md
+++ b/docs/E2E_TESTING_GUIDE.md
@@ -1,0 +1,129 @@
+# End-to-End Testing Guide
+
+HEMA Scorecard has an automated end-to-end (E2E) test suite built on
+[Playwright](https://playwright.dev). No prior Playwright/TypeScript/GitHub Actions experience needed.
+
+## What and why
+
+An E2E test starts a real copy of the app (PHP + MySQL + a real browser),
+loads pages, fills forms, and checks the result — the same way a user would.
+It catches regressions at the pull request instead of at a tournament, hopefully.
+
+## The pieces
+
+| Piece | What it is |
+|---|---|
+| `docker-compose.test.yml` | Test specific Docker Compose with it's own configuration for running tests. |
+| `tests/fixtures/seed.sql` | Fixed test data for the database. |
+| `tests/fixtures/credentials.md` | Cheat sheet of seeded logins, IDs, and names. |
+| `tests/reset-db.sh` | Helper script that will reset the test DB to seed values. |
+| `healthcheck.php` | Returns 200 when app + DB are ready; used to wait for startup inside of test suite. |
+| `playwright.config.ts` | Playwright settings. Ideally shouldn't get messed with much. |
+| `tests/e2e/*.spec.ts` | Test files. We have two smoke tests for the test harness itself and 1 sample test. |
+| `.github/workflows/e2e.yml` | Runs the suite on GitHub for every PR. |
+
+## Running locally
+
+One-time setup (needs Docker Desktop and Node.js):
+
+```bash
+npm install
+npx playwright install chromium
+```
+
+Every time:
+
+```bash
+npm run test:stack:up      # start the test app (~30-60s first boot)
+npm run test:e2e           # run the suite (waits + resets DB automatically)
+npm run test:stack:down    # stop it
+```
+
+The test stack uses port 8000, same as the dev stack — only one at a time.
+
+Other commands:
+
+```bash
+npm run test:e2e:ui        # visual UI; best way to debug a failing test
+npm run test:db:reset      # manual DB reset
+npx playwright test tests/e2e/smoke.spec.ts   # one file only
+npx playwright show-report # screenshots/traces from the last failing run
+```
+
+## Anatomy of a test
+
+From `tests/e2e/public-pages.spec.ts`:
+
+```ts
+import { test, expect } from '@playwright/test';
+import { TEST_EVENT_ID, TEST_EVENT_NAME } from './helpers/test-data';
+
+test('event summary page renders the seeded event and tournament', async ({ page }) => {
+  await page.goto(`/infoSummary.php?e=${TEST_EVENT_ID}`);
+
+  await expect(page.getByText(TEST_EVENT_NAME).first()).toBeVisible();
+  await expect(page.getByText('Longsword').first()).toBeVisible();
+});
+```
+
+- `page` is a real browser tab Playwright controls; `await` means "wait for
+  this step to finish".
+- `page.goto(...)` navigates (relative to `http://localhost:8000`).
+- `expect(...).toBeVisible()` is the check — it waits and retries for a few
+  seconds, then fails with a screenshot.
+- Seeded IDs/names come from `tests/e2e/helpers/test-data.ts` — always use
+  those constants instead of retyping values.
+
+**Login is handled by file name:**
+
+- `*.spec.ts` — runs logged out (public pages).
+- `*.auth.spec.ts` — runs already logged in as the event organizer
+  (`auth.setup.ts` logs in once and shares the session cookie). Never write
+  login code in a test.
+
+**Writing a new test:** pick the file name by login need, copy an existing
+test, change the page and checks, run that file. Find elements like a user
+would — `getByText`, `getByLabel`, `getByRole` — or add a `data-testid`
+attribute to the PHP template if a page has nothing to grab.
+
+Two rules:
+
+- **Tests must not depend on each other.** The DB resets per run, not per
+  test — a test that mutates data must create what it needs itself.
+- **No hard-coded waits** (`waitForTimeout`). `expect(...)` already retries.
+
+## CI (GitHub Actions)
+
+`.github/workflows/e2e.yml` makes GitHub run the full suite on a fresh machine
+for every PR and push to master. Each PR gets a ✅/❌ automatically; on
+failure, click **Details** for the log and download the `playwright-report`
+artifact for screenshots and traces. To reproduce, run the suite locally —
+it's the same tests against the same seed.
+
+Once stable, make `e2e` a required status check (repo Settings → Branches) so
+red blocks merging.
+
+## Future work policy
+
+1. **Every bug fix gets a test** — write it failing first, fix, watch it pass.
+2. **New features ship with at least one test** covering the main path.
+3. **Highest-value tests to add next:** login/permission checks, then the full
+   tournament journey (create → add fighters → pools → score → verify
+   standings), then brackets.
+
+Notes:
+
+- Tests run serially (`workers: 1`) because they share one session-based app
+  and one DB. Parallelization is future work we aren't bothering with now.
+- If the seed grows, update `seed.sql` + `test-data.ts` + `credentials.md`
+  together. Keep the seed minimal — create pools/matches through the UI in
+  tests instead.
+
+## Troubleshooting
+
+| Symptom | Fix |
+|---|---|
+| `App not ready ... did not return 200` | Start the stack (`npm run test:stack:up`); make sure the dev stack isn't on port 8000. First boot takes ~30–60s. |
+| Connection errors mid-run | Docker stopped or stack went down. |
+| All `.auth` tests fail at setup | Seed didn't load: `npm run test:db:reset`; check `seed.sql` for syntax errors. |
+| Weird failures after editing `seed.sql` | `npm run test:db:reset`, or restart the stack. |

--- a/healthcheck.php
+++ b/healthcheck.php
@@ -1,0 +1,37 @@
+<?php
+/*******************************************************************************
+	Health-check endpoint for CI/test readiness polling.
+
+	Returns 200 "OK" once the app can reach the database AND the schema/seed
+	is loaded (systemEvents exists), 503 otherwise. Deliberately does not
+	include config.php/header.php to avoid session and POST machinery.
+
+*******************************************************************************/
+
+// database.php references this constant, normally defined in config.php
+if(!defined('DEPLOYMENT_UNKNOWN')){ define('DEPLOYMENT_UNKNOWN', 0); }
+
+include(__DIR__.'/includes/database.php');
+
+mysqli_report(MYSQLI_REPORT_OFF);
+$link = @mysqli_connect(DATABASE_HOST, DATABASE_USER, DATABASE_PASSWORD, PRIMARY_DATABASE);
+
+if($link === false){
+	http_response_code(503);
+	echo "DB UNAVAILABLE";
+	exit;
+}
+
+$result = @mysqli_query($link, "SELECT 1 FROM systemEvents LIMIT 1");
+
+if($result === false){
+	http_response_code(503);
+	echo "SCHEMA NOT LOADED";
+} else {
+	echo "OK";
+}
+
+mysqli_close($link);
+
+// END OF FILE /////////////////////////////////////////////////////////////////
+////////////////////////////////////////////////////////////////////////////////

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,79 @@
+{
+  "name": "hemascorecard",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "hemascorecard",
+      "version": "1.0.0",
+      "license": "ISC",
+      "devDependencies": {
+        "@playwright/test": "1.61.1"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,28 @@
+{
+  "name": "hemascorecard",
+  "version": "1.0.0",
+  "description": "HEMA Scorecard - Tournament Management Software",
+  "private": true,
+  "scripts": {
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui",
+    "test:stack:up": "docker compose -f docker-compose.test.yml -p hemascorecard-test up -d",
+    "test:stack:down": "docker compose -f docker-compose.test.yml -p hemascorecard-test down",
+    "test:db:reset": "bash tests/reset-db.sh"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/pearsall-will/hemaScorecard.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "bugs": {
+    "url": "https://github.com/pearsall-will/hemaScorecard/issues"
+  },
+  "homepage": "https://github.com/pearsall-will/hemaScorecard#readme",
+  "devDependencies": {
+    "@playwright/test": "1.61.1"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,55 @@
+import { defineConfig, devices } from '@playwright/test';
+
+/**
+ * E2E test config. Expects the dockerized test stack to be running:
+ *   docker compose -f docker-compose.test.yml -p hemascorecard-test up -d
+ *
+ * Global setup waits for healthcheck.php and resets the DB to the seed
+ * state (tests/reset-db.sh) before every run.
+ */
+export default defineConfig({
+  testDir: './tests/e2e',
+  globalSetup: './tests/e2e/helpers/global-setup',
+
+  // The app is session-based and all tests share one database — parallel
+  // workers would collide. Keep serial until per-worker DB isolation exists.
+  fullyParallel: false,
+  workers: 1,
+
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['list'], ['html', { open: 'never' }]] : 'list',
+
+  use: {
+    baseURL: process.env.BASE_URL || 'http://localhost:8000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    // Logs in as event organizer and saves the session cookie for the
+    // 'authenticated' project.
+    {
+      name: 'setup',
+      testMatch: /.*\.setup\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // Public pages — no login. Any tests/e2e/*.spec.ts not named *.auth.spec.ts.
+    {
+      name: 'public',
+      testMatch: /.*\.spec\.ts/,
+      testIgnore: /.*\.auth\.spec\.ts/,
+      use: { ...devices['Desktop Chrome'] },
+    },
+    // Organizer-authenticated pages — tests named *.auth.spec.ts.
+    {
+      name: 'authenticated',
+      testMatch: /.*\.auth\.spec\.ts/,
+      dependencies: ['setup'],
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'tests/e2e/.auth/organizer.json',
+      },
+    },
+  ],
+});

--- a/tests/e2e/auth.setup.ts
+++ b/tests/e2e/auth.setup.ts
@@ -1,0 +1,25 @@
+import { test as setup, expect } from '@playwright/test';
+import {
+  ORGANIZER_PASSWORD,
+  ORGANIZER_STORAGE_STATE,
+  TEST_EVENT_ID,
+} from './helpers/test-data';
+
+/**
+ * Logs in as the event organizer for the seeded test event and saves the
+ * PHP session cookie. The 'authenticated' project loads this storageState
+ * so tests don't repeat the login flow.
+ */
+setup('authenticate as event organizer', async ({ page }) => {
+  await page.goto('/adminLogIn.php');
+
+  await page.locator('#logInType').selectOption('logInOrganizer');
+  await page.locator('#logInEventID').selectOption(String(TEST_EVENT_ID));
+  await page.locator("input[name='logInData[password]']").fill(ORGANIZER_PASSWORD);
+  await page.locator('#logInSubmitButton').click();
+
+  // The header only renders "Log Out" for a logged-in session.
+  await expect(page.getByRole('link', { name: 'Log Out' }).first()).toBeVisible();
+
+  await page.context().storageState({ path: ORGANIZER_STORAGE_STATE });
+});

--- a/tests/e2e/helpers/global-setup.ts
+++ b/tests/e2e/helpers/global-setup.ts
@@ -1,0 +1,35 @@
+import { execSync } from 'child_process';
+import type { FullConfig } from '@playwright/test';
+
+const HEALTHCHECK_TIMEOUT_MS = 120_000;
+const POLL_INTERVAL_MS = 3_000;
+
+/**
+ * Runs once before the whole suite:
+ *  1. Waits for the dockerized app + seeded DB to be ready (healthcheck.php).
+ *  2. Resets the database to the seed state so every run is deterministic.
+ */
+export default async function globalSetup(config: FullConfig) {
+  const baseURL = config.projects[0].use.baseURL || 'http://localhost:8000';
+  const healthURL = `${baseURL}/healthcheck.php`;
+
+  const deadline = Date.now() + HEALTHCHECK_TIMEOUT_MS;
+  for (;;) {
+    try {
+      const res = await fetch(healthURL);
+      if (res.status === 200) break;
+    } catch {
+      // stack still starting
+    }
+    if (Date.now() > deadline) {
+      throw new Error(
+        `App not ready: ${healthURL} did not return 200 within ${HEALTHCHECK_TIMEOUT_MS / 1000}s.\n` +
+          'Start the test stack first:\n' +
+          '  docker compose -f docker-compose.test.yml -p hemascorecard-test up -d',
+      );
+    }
+    await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+  }
+
+  execSync('bash tests/reset-db.sh', { stdio: 'inherit' });
+}

--- a/tests/e2e/helpers/test-data.ts
+++ b/tests/e2e/helpers/test-data.ts
@@ -1,0 +1,21 @@
+/**
+ * Constants matching the seeded fixture (tests/fixtures/seed.sql).
+ * See tests/fixtures/credentials.md for the full reference.
+ */
+export const TEST_EVENT_ID = 1;
+export const TEST_EVENT_NAME = 'Playwright Test Event';
+export const TEST_TOURNAMENT_ID = 1;
+
+export const ORGANIZER_PASSWORD = 'organizer-test-pw';
+export const STAFF_PASSWORD = 'staff-test-pw';
+
+export const ORGANIZER_STORAGE_STATE = 'tests/e2e/.auth/organizer.json';
+
+export const FIGHTERS = [
+  { rosterID: 1, firstName: 'Alice', lastName: 'Applegate' },
+  { rosterID: 2, firstName: 'Brett', lastName: 'Bowman' },
+  { rosterID: 3, firstName: 'Carol', lastName: 'Chandler' },
+  { rosterID: 4, firstName: 'Dmitri', lastName: 'Dukas' },
+  { rosterID: 5, firstName: 'Erin', lastName: 'Eastwood' },
+  { rosterID: 6, firstName: 'Frank', lastName: 'Fischer' },
+];

--- a/tests/e2e/public-pages.spec.ts
+++ b/tests/e2e/public-pages.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+import { TEST_EVENT_ID, TEST_EVENT_NAME } from './helpers/test-data';
+
+/**
+ * Phase 3 — public/read-only pages. No login, no writes.
+ */
+test('event summary page renders the seeded event and tournament', async ({ page }) => {
+  await page.goto(`/infoSummary.php?e=${TEST_EVENT_ID}`);
+
+  // Session-driven redirect selects the event's only tournament.
+  await expect(page).toHaveURL(new RegExp(`infoSummary\\.php\\?e=${TEST_EVENT_ID}&t=1`));
+  await expect(page.getByText(TEST_EVENT_NAME).first()).toBeVisible();
+  await expect(page.getByText('Longsword').first()).toBeVisible();
+});

--- a/tests/e2e/public-pages.spec.ts
+++ b/tests/e2e/public-pages.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { TEST_EVENT_ID, TEST_EVENT_NAME } from './helpers/test-data';
 
 /**
- * Phase 3 — public/read-only pages. No login, no writes.
+ * public/read-only pages. No login, no writes.
  */
 test('event summary page renders the seeded event and tournament', async ({ page }) => {
   await page.goto(`/infoSummary.php?e=${TEST_EVENT_ID}`);

--- a/tests/e2e/smoke.auth.spec.ts
+++ b/tests/e2e/smoke.auth.spec.ts
@@ -1,0 +1,15 @@
+import { test, expect } from '@playwright/test';
+import { TEST_EVENT_NAME } from './helpers/test-data';
+
+/**
+ * Authenticated smoke test — proves the storageState produced by
+ * auth.setup.ts carries a working organizer session.
+ */
+test('organizer session reaches tournament administration', async ({ page }) => {
+  await page.goto('/adminTournaments.php');
+
+  // Session-driven redirect appends the current event/tournament.
+  await expect(page).toHaveURL(/adminTournaments\.php\?e=1&t=1/);
+  await expect(page.getByText(TEST_EVENT_NAME).first()).toBeVisible();
+  await expect(page.getByRole('link', { name: 'Log Out' }).first()).toBeVisible();
+});

--- a/tests/e2e/smoke.spec.ts
+++ b/tests/e2e/smoke.spec.ts
@@ -1,0 +1,25 @@
+import { test, expect } from '@playwright/test';
+import { FIGHTERS, TEST_EVENT_ID } from './helpers/test-data';
+
+/**
+ * Harness smoke tests — public pages, no login. Prove the dockerized app
+ * serves pages and the seed data is present.
+ */
+test('landing page loads', async ({ page }) => {
+  await page.goto('/index.php');
+  await expect(page).toHaveTitle(/HEMA Scorecard/);
+});
+
+test('login page shows the login form', async ({ page }) => {
+  await page.goto('/adminLogIn.php');
+  await expect(page.locator('#logInType')).toBeVisible();
+  await expect(page.locator("input[name='logInData[password]']")).toBeVisible();
+  await expect(page.locator('#logInSubmitButton')).toBeVisible();
+});
+
+test('public roster shows the seeded fighters', async ({ page }) => {
+  await page.goto(`/participantsEvent.php?e=${TEST_EVENT_ID}`);
+  for (const fighter of FIGHTERS) {
+    await expect(page.getByText(fighter.lastName).first()).toBeVisible();
+  }
+});

--- a/tests/fixtures/credentials.md
+++ b/tests/fixtures/credentials.md
@@ -1,0 +1,53 @@
+# Test Fixture Reference
+
+Seeded by `tests/fixtures/seed.sql` (applied automatically by
+`docker-compose.test.yml` on first boot, or by `tests/reset-db.sh`).
+
+## Credentials
+
+| Login type | Password | Where checked |
+|---|---|---|
+| Event organizer (event 1) | `organizer-test-pw` | `eventSettings.organizerPassword` (bcrypt) |
+| Event staff (event 1) | `staff-test-pw` | `eventSettings.staffPassword` (bcrypt) |
+| System user `admin` | *(any — password is NULL)* | `systemUsers.password`, seeded by `Tables - Setup_Docker.sql` |
+
+Wrong passwords for organizer/staff **are rejected** (real bcrypt hashes are
+seeded), so negative auth tests work. The `admin` system user accepts any
+password — a quirk of `checkPassword()` treating NULL as "no password set".
+
+## Seeded data
+
+- **Event 1** — "Playwright Test Event" (PTE), 2026, active, all publication
+  flags on (roster/schedule/matches/rules publicly visible).
+- **Tournament 1** — FORMAT_MATCH (Sparring Matches), Longsword,
+  Franklin 2014 ranking, deductive afterblow, max pool size 5.
+- **School 1** — "Test Fencing School" (TFS).
+- **Fighters** (rosterID = systemRosterID, all checked in, waivers signed):
+
+| rosterID | Name |
+|---|---|
+| 1 | Alice Applegate |
+| 2 | Brett Bowman |
+| 3 | Carol Chandler |
+| 4 | Dmitri Dukas |
+| 5 | Erin Eastwood |
+| 6 | Frank Fischer |
+
+No pools, groups, or matches are seeded — journey tests create those through
+the UI.
+
+## Environment commands
+
+```bash
+# start isolated test stack (fresh DB every up; dev ./data untouched)
+docker compose -f docker-compose.test.yml -p hemascorecard-test up -d
+
+# wait for readiness
+curl http://localhost:8000/healthcheck.php   # 200 "OK" when ready
+
+# reset DB to seed state between runs (no container restart)
+tests/reset-db.sh
+
+# tear down
+docker compose -f docker-compose.test.yml -p hemascorecard-test down
+```

--- a/tests/fixtures/seed.sql
+++ b/tests/fixtures/seed.sql
@@ -1,0 +1,63 @@
+-- ============================================================================
+-- Deterministic seed data for E2E testing (Playwright).
+--
+-- Loaded after the schema (Tables - ScorecardV9.sql) and the docker admin
+-- user (Tables - Setup_Docker.sql), either by /docker-entrypoint-initdb.d
+-- ordering in docker-compose.test.yml or by tests/reset-db.sh.
+--
+-- Test credentials (see tests/fixtures/credentials.md):
+--   event organizer password: organizer-test-pw
+--   event staff password:     staff-test-pw
+-- Hashes below are bcrypt via PHP password_hash(..., PASSWORD_DEFAULT).
+-- ============================================================================
+
+-- Test event (eventID 1 = DEFAULT_EVENT in includes/config.php)
+INSERT INTO `systemEvents`
+	(`eventID`, `eventName`, `eventAbbreviation`, `eventYear`, `eventStartDate`, `eventEndDate`, `countryIso2`, `eventCity`, `eventStatus`, `isArchived`, `isMetaEvent`)
+VALUES
+	(1, 'Playwright Test Event', 'PTE', 2026, '2026-06-01', '2026-06-02', 'US', 'Testville', 'active', 0, 0);
+
+INSERT INTO `eventSettings`
+	(`eventSettingID`, `eventID`, `organizerEmail`, `termsOfUseAccepted`, `staffPassword`, `organizerPassword`)
+VALUES
+	(1, 1, 'test@example.com', 1, '$2y$10$IsEUmPgLPbAF0/bNTSAiE.xXxQFcH0HOY3lseV0iK4164YxPTkQkq', '$2y$10$rbFiSVNG9R4QJ9engQclSuhPjFqa36s7ixB.AfoiS/mM1GmMTAN8i');
+
+INSERT INTO `eventDefaults` (`tableID`, `eventID`) VALUES (1, 1);
+
+INSERT INTO `eventPublication`
+	(`publicationID`, `eventID`, `publishDescription`, `publishRoster`, `publishSchedule`, `publishMatches`, `publishRules`)
+VALUES
+	(1, 1, 1, 1, 1, 1, 1);
+
+-- Tournament: FORMAT_MATCH (2), Longsword (systemTournaments ID 1),
+-- Franklin 2014 ranking (systemRankings ID 1). Other columns keep schema defaults.
+INSERT INTO `eventTournaments`
+	(`tournamentID`, `eventID`, `tournamentWeaponID`, `tournamentRankingID`, `doubleTypeID`, `formatID`, `color1ID`, `color2ID`, `maxPoolSize`, `maxDoubleHits`)
+VALUES
+	(1, 1, 1, 1, 2, 2, 1, 2, 5, 3);
+
+-- School for the roster
+INSERT INTO `systemSchools`
+	(`schoolID`, `schoolFullName`, `schoolShortName`, `schoolAbbreviation`, `countryIso2`)
+VALUES
+	(1, 'Test Fencing School', 'Test School', 'TFS', 'US');
+
+-- Six fighters with fixed IDs and predictable names
+INSERT INTO `systemRoster` (`systemRosterID`, `firstName`, `lastName`, `schoolID`) VALUES
+	(1, 'Alice',  'Applegate', 1),
+	(2, 'Brett',  'Bowman',    1),
+	(3, 'Carol',  'Chandler',  1),
+	(4, 'Dmitri', 'Dukas',     1),
+	(5, 'Erin',   'Eastwood',  1),
+	(6, 'Frank',  'Fischer',   1);
+
+INSERT INTO `eventRoster` (`rosterID`, `systemRosterID`, `eventID`, `schoolID`, `isTeam`, `eventCheckIn`, `eventWaiver`) VALUES
+	(1, 1, 1, 1, 0, 1, 1),
+	(2, 2, 1, 1, 0, 1, 1),
+	(3, 3, 1, 1, 0, 1, 1),
+	(4, 4, 1, 1, 0, 1, 1),
+	(5, 5, 1, 1, 0, 1, 1),
+	(6, 6, 1, 1, 0, 1, 1);
+
+-- No pools/groups/matches are seeded: E2E journey tests create those through
+-- the UI, keeping this fixture decoupled from eventGroups/eventMatches FKs.

--- a/tests/reset-db.sh
+++ b/tests/reset-db.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Reset the test database to its seeded state without restarting containers.
+#
+# Drops and recreates the schema inside the running test-stack MySQL
+# container, then replays the same init files docker-entrypoint-initdb.d
+# used on first boot (mounted read-only into the container by
+# docker-compose.test.yml).
+#
+# Usage: tests/reset-db.sh
+set -euo pipefail
+
+COMPOSE=(docker compose -f docker-compose.test.yml -p hemascorecard-test)
+DB_NAME="${PRIMARY_DATABASE:-ScorecardV5}"
+
+"${COMPOSE[@]}" exec -T db sh -c '
+  set -e
+  DB_NAME="$1"
+  MYSQL="mysql -uroot -p$MYSQL_ROOT_PASSWORD"
+  $MYSQL -e "DROP DATABASE IF EXISTS \`$DB_NAME\`; CREATE DATABASE \`$DB_NAME\`;"
+  for f in /docker-entrypoint-initdb.d/01-schema.sql \
+           /docker-entrypoint-initdb.d/02-users.sql \
+           /docker-entrypoint-initdb.d/03-seed.sql; do
+    $MYSQL "$DB_NAME" < "$f"
+  done
+' sh "$DB_NAME"
+
+echo "Database '$DB_NAME' reset to seed state."


### PR DESCRIPTION
Adding end to end testing harness using playwright. See included docs\E2E_TESTING_GUIDE.md for the explanation on what all it's doing and why.

Goal is to add some automated testing into the repo. Setup to use GH Actions to run on PR (every user gets 2k minutes free per month so hopefully we can just do this for free for now.)

You can see runs of the action and the test results in my fork [here](https://github.com/pearsall-will/hemaScorecard/actions)