### PR TITLE
Misc Display Improvements

### DIFF
--- a/includes/header.php
+++ b/includes/header.php
@@ -243,6 +243,12 @@ if(    ALLOW['EVENT_MANAGEMENT'] == true
 			$navBarString .= "<li><a href='cutQualsTournament.php'>Cutting Qualification</a></li>";
 		}
 
+		// Tournament is results only.
+		// Many people select this by mistake and are confused why they can't make pools.
+		if($_SESSION['formatID'] == FORMAT_RESULTS && ALLOW['EVENT_MANAGEMENT'] == true){
+			$navBarString .= "<li><i>(This is a results-only tournament. Change the Tournament Type to 'Sparring Matches' for a standard fencing tournament.)</i></li>";
+		}
+
 		?>
 
 		<?php if(isset($navBarString)): ?>

--- a/participantsEvent.php
+++ b/participantsEvent.php
@@ -137,7 +137,6 @@ function displayEventRoster($roster, $isTournamentScheduleUsed,
 	<?php
 
 	tableHeaders();
-	$i = 0;
 
 	foreach ((array)$roster as $person):
 
@@ -236,14 +235,6 @@ function displayEventRoster($roster, $isTournamentScheduleUsed,
 		<tr id='tList2-<?=$rosterID?>' class='hidden'>
 			<td colspan='100%' ></td>
 		</tr>
-
-		<?php
-		// Repeats the header row every 15 entries
-		$i++;
-		if($i >= 15){
-			$i=0;
-			tableHeaders();
-		}?>
 
 	<?php endforeach?>
 

--- a/poolStandings.php
+++ b/poolStandings.php
@@ -43,6 +43,7 @@ if($tournamentID == null){
 	poolSetNavigation($displayPoolsOption);
 
 	$incompleteMatches = getTournamentPoolIncompletes($tournamentID, $_SESSION['groupSet']);
+	$numIncompleteMatches = (int)count($incompleteMatches);
 	$incompleteComponents = getIncompletComponents($tournamentID);
 
 	$teamRoster = getTournamentTeams($tournamentID);
@@ -63,9 +64,9 @@ if($tournamentID == null){
 ////////////////////////////////////////////////////////////////////////////////
 ?>
 
-	<?php if($incompleteMatches != null): ?>
+	<?php if($numIncompleteMatches != 0): ?>
 		<div class='large-12 callout secondary text-center'>
-		<p>All pool matches not yet concluded. <BR>
+		<p>All pool matches not yet concluded. (<?=$numIncompleteMatches?> remain)<BR>
 		Results may be extrapolated based on matches concluded so far.</p>
 		<?php if(ALLOW['EVENT_SCOREKEEP'] == true || ALLOW['VIEW_SETTINGS'] == true): ?>
 			<button class='button hollow' onclick="toggle('incompleteMatchesDiv')">

--- a/scoreMatchDisplay.php
+++ b/scoreMatchDisplay.php
@@ -216,28 +216,25 @@ function poolMatchQueue($matchInfo){
 
 	$remainingMatches = [];
 	$matches = getRemainingPoolMatches($matchInfo);
-	$matchesShown = 0;
-	$matchesHidden = 0;
+	$numMatchesLeft = 0;
 
 	foreach($matches as $m){
 
-		if($matchesShown < 3){
+		if($numMatchesLeft < 3){
 			$tmp = [];
 			$tmp['name'][1] = getFighterName($m['fighter1ID']);
 			$tmp['name'][2] = getFighterName($m['fighter2ID']);
 			$remainingMatches[] = $tmp;
-			$matchesShown++;
+			$numMatchesLeft++;
 		} else {
-			$matchesHidden++;
+			$numMatchesLeft++;
 		}
 	}
 
-	if($matchesHidden > 0){
-		$moreMatchesText = "<i>And {$matchesHidden} more ...</i>";
-	} else {
-		//$moreMatchesText = "- End of Pool ----";
-		$moreMatchesText = "--------------------<BR> End of Pool";
+	if((int)$matchInfo['matchComplete'] == 0){
+		$numMatchesLeft++;
 	}
+
 
 ?>
 
@@ -272,8 +269,18 @@ function poolMatchQueue($matchInfo){
 			</div>
 		<?php endforeach ?>
 
-		<div style='margin: 10px; color: white; font-size:2em;'>
-			<?=$moreMatchesText?>
+		<div style='margin: 10px; color: white; font-size:1em;'>
+			<table>
+				<tr>
+					<td rowspan='2' style='text-align: center; font-size:8em; background-color: black; margin: 0px; padding: 0px;line-height: 1.1;'>
+						<b><?=$numMatchesLeft?><b>
+					</td>
+					<td style=' vertical-align: bottom; background-color: black;'><i>matches</i></td>
+				</tr>
+				<tr>
+					<td style=' vertical-align: top;background-color: black;'><i>remain</i></td>
+				</tr>
+			</table>
 		</div>
 
 


### PR DESCRIPTION
Fixes from #203  
3) Have the match On Deck window show a big count of how many matches are left in the pool total. Big enough so the director can see it on the other side of the ring.
4) Have the pool standings say how many matches are left
5) Lighten the blue color so that it has better contrast with the black text (changed DB color code for blue from #1C6CD8 to #17A0DD 6) Give some sort of warning when the event organizer is in Results Only tournament mode. There are a lot of questions of "why can't I make pools" when people set their tournaments to the wrong type,
7) Figure out how to get table headers to float at the top of the page when you scroll down. 8) Remove the Name/School rows from the Event Participants table. They are kind of redundant now.