### PR TITLE
Preserve the tournament context for longer

### DIFF
--- a/includes/config.php
+++ b/includes/config.php
@@ -63,6 +63,8 @@
 	define("DEFAULT_TOURNAMENT_ID",0);
 	define("TEST_EVENT_ID",2);
 
+	define("CONTEXT_COOKIE_LIFETIME",60*60*24*4);	// 4 days
+
 	define("FINALS","0");
 	define("ALL_GROUP_SETS",0);
 
@@ -255,6 +257,9 @@ require_once(BASE_URL.'includes/function_lib.php');
 $conn = connectToDB();
 
 // Set Session Values //////////////////////////////////////////////////////////
+
+// Restore last viewed context
+	restoreContextFromCookie();
 
 // Set the Permissions
 	setPermissions();
@@ -545,6 +550,39 @@ VIEW_SETTINGS
 VIEW_EMAIL
 	- Can view event organizer e-mail addresses.
 */
+
+}
+
+/******************************************************************************/
+
+function restoreContextFromCookie(){
+// Restores the last viewed event and tournament after the session has expired
+
+	if(!empty($_SESSION['eventID']) || empty($_COOKIE['lastViewedContext'])){
+		return;
+	}
+
+	$IDs = explode('-', $_COOKIE['lastViewedContext']);
+	$eventID = (int)($IDs[0] ?? 0);
+	$tournamentID = (int)($IDs[1] ?? 0);
+
+	if($eventID == 0 || isEventPublished($eventID) == false){
+		return;
+	}
+
+	$_SESSION['eventID'] = $eventID;
+	$_SESSION['isMetaEvent'] = isMetaEvent($eventID);
+
+	if($tournamentID != 0){
+		$sql = "SELECT tournamentID
+				FROM eventTournaments
+				WHERE eventID = {$eventID}
+				AND tournamentID = {$tournamentID}";
+
+		if((bool)mysqlQuery($sql, SINGLE, null) == true){
+			$_SESSION['tournamentID'] = $tournamentID;
+		}
+	}
 
 }
 

--- a/includes/config.php
+++ b/includes/config.php
@@ -558,7 +558,9 @@ VIEW_EMAIL
 function restoreContextFromCookie(){
 // Restores the last viewed event and tournament after the session has expired
 
-	if(!empty($_SESSION['eventID']) || empty($_COOKIE['lastViewedContext'])){
+	if(!empty($_SESSION['eventID'])
+	   || !empty($_SESSION['userName'])
+	   || empty($_COOKIE['lastViewedContext'])){
 		return;
 	}
 
@@ -694,5 +696,3 @@ function initializeSession(){
 
 // END OF FILE /////////////////////////////////////////////////////////////////
 ////////////////////////////////////////////////////////////////////////////////
-
-

--- a/includes/functions/doPOST.php
+++ b/includes/functions/doPOST.php
@@ -869,6 +869,8 @@ function changeTournament($tournamentID, $matchID = 0){
 	$_SESSION['bracketHelper'] = '';
 	$_SESSION['groupSet'] = 1;
 
+	setcookie('lastViewedContext', (int)$_SESSION['eventID']."-".(int)$tournamentID, time()+CONTEXT_COOKIE_LIFETIME, '/', '', false, true);
+
 
 	if(isset($_SESSION['hideAnnouncement']) == true && $tournamentID != 0){
 


### PR DESCRIPTION
Keeps a backup context in a cookie so that when you grab your phone later you don't need to re-select the tournament again.