### PR TITLE
Make entire mobile Menu control a tappable toggle

### DIFF
--- a/includes/foundation/css/custom.css
+++ b/includes/foundation/css/custom.css
@@ -915,6 +915,17 @@ h2 {
   display:block;
 }
 
+/* The whole Menu control (icon + label) is the toggle, sized as a 44px touch target */
+.title-bar .menu-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  min-width: 44px;
+  min-height: 44px;
+  padding: .25rem .5rem;
+  cursor: pointer;
+}
+
 .title-bar .login-link {
   /* display:inline-block; */
   float:right;

--- a/includes/foundation/css/custom.css
+++ b/includes/foundation/css/custom.css
@@ -927,9 +927,11 @@ h2 {
 }
 
 .title-bar .login-link {
-  /* display:inline-block; */
   float:right;
   color:white;
+  display: inline-flex;
+  min-height: 44px;
+  align-items: center;
   margin: 0 .5rem;
 }
 

--- a/includes/header.php
+++ b/includes/header.php
@@ -13,7 +13,7 @@
 include_once('includes/config.php');
 
 $vJ = '?=1.9.11'; // Javascript Version
-$vC = '?=1.4.0'; // CSS Version
+$vC = '?=1.4.1'; // CSS Version
 
 if(    ALLOW['EVENT_MANAGEMENT'] == true
 	|| ALLOW['VIEW_SETTINGS'] == true
@@ -93,8 +93,10 @@ if(    ALLOW['EVENT_MANAGEMENT'] == true
 	<!-- Mobile Navigation -->
 	<div class="title-bar" data-responsive-toggle="tourney-animated-menu" data-hide-for="large" style='display:none'>
 		<form method='POST' name='logOutForm1'>
-		<button class="menu-icon" type="button" data-toggle></button>
-		<div class="title-bar-title">Menu</div>
+		<button class="menu-toggle" type="button" data-toggle>
+			<span class="menu-icon"></span>
+			<span class="title-bar-title">Menu</span>
+		</button>
 
 		<?php if($_SESSION['userName'] == null): ?>
 			<a href='adminLogIn.php' class='login-link'>Login</a>

--- a/tests/e2e/mobile-nav.spec.ts
+++ b/tests/e2e/mobile-nav.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect, devices, type Page } from '@playwright/test';
+import { TEST_EVENT_ID } from './helpers/test-data';
+
+/**
+ * Mobile hamburger navigation. The toggle must be tappable on the whole
+ * "Menu" control, not just the 20x16px hamburger icon.
+ */
+test.use({ ...devices['iPhone 13'] });
+
+const menu = (page: Page) => page.locator('#tourney-animated-menu');
+
+test('tapping the "Menu" text opens the mobile navigation', async ({ page }) => {
+  await page.goto(`/infoSummary.php?e=${TEST_EVENT_ID}`);
+
+  await expect(menu(page)).toBeHidden();
+  await page.tap('.title-bar .title-bar-title');
+  await expect(menu(page)).toBeVisible();
+});
+
+test('mobile menu toggle has an adequate touch target', async ({ page }) => {
+  await page.goto(`/infoSummary.php?e=${TEST_EVENT_ID}`);
+
+  const box = await page.locator('.title-bar [data-toggle]').boundingBox();
+  expect(box).not.toBeNull();
+  expect(box!.height).toBeGreaterThanOrEqual(44);
+  expect(box!.width).toBeGreaterThanOrEqual(44);
+});


### PR DESCRIPTION
Our long national nightmare of rage tapping the hamburger menu can be over.  Previously only the 20x16px hamburger icon triggered the mobile nav (i.e., tapping the "Menu" label did nothing), which is far below the recommended tap target size of like 45px on both dimensions.  On a desktop simulator, it wasn't too bad, but on a real phone, it could be a nightmare to tap.  

This PR wraps both the icon and label in a single touch target, making it much larger and easier to trigger.